### PR TITLE
Upgrade Git Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM teracy/ubuntu:18.04-dind-latest
 
 # Extra deps for GHA Runner
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN add-apt-repository ppa:git-core/ppa && apt-get update \
     && apt-get install -y \
     curl \
     dnsutils \


### PR DESCRIPTION
We were having some issues on some git dependent pipelines where the runner issue the following warning:

```
/usr/bin/git version
git version 2.17.1
The repository will be downloaded using the GitHub REST API
To create a local Git repository instead, add Git 2.18 or higher to the PATH
```
We soon will upgrade the entire image, but until we get there this `ppa` gets the job done. Current version goes to 2.29.2. 