### PR TITLE
Use assume role on test Action

### DIFF
--- a/.github/workflows/manual_test.yaml
+++ b/.github/workflows/manual_test.yaml
@@ -14,7 +14,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
         aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
         role-to-assume: ${{ secrets.AWS_ECS_RUN_TASK_ROLE }}
-        role-duration-seconds: 600
+        role-duration-seconds: 900
     - name: Provide a self hosted to execute this job
       uses: PasseiDireto/gh-runner-task-action@main
       with:

--- a/.github/workflows/manual_test.yaml
+++ b/.github/workflows/manual_test.yaml
@@ -7,16 +7,21 @@ jobs:
   pre-job-test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+        role-to-assume: ${{ secrets.AWS_ECS_RUN_TASK_ROLE }}
+        role-duration-seconds: 600
     - name: Provide a self hosted to execute this job
       uses: PasseiDireto/gh-runner-task-action@main
       with:
         github_pat: ${{ secrets.PD_BOT_GITHUB_ACCESS_TOKEN }}
         task_definition: 'gh-runner'
         cluster: 'gh-runner'
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.CDK_ACCESS_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.CDK_SECRET_KEY }}
-        AWS_DEFAULT_REGION:  ${{secrets.AWS_DEFAULT_REGION}}
+
   runs-dummy-action:
     runs-on: self-hosted
     container:


### PR DESCRIPTION
Use AssumeRole from [aws-configure-credentials](https://github.com/aws-actions/configure-aws-credentials) in order to configure the [gh-runner-task-action](https://github.com/PasseiDireto/gh-runner-task-action/) to run the test worfklow.