### PR TITLE
fix/replace-secret Replace old secret

### DIFF
--- a/.github/workflows/manual_test.yaml
+++ b/.github/workflows/manual_test.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Provide a self hosted to execute this job
       uses: PasseiDireto/gh-runner-task-action@main
       with:
-        github_pat: ${{ secrets.PD_BOT_GITHUB_ACCESS_TOKEN }}
+        github_pat: ${{ secrets.PD_GITHUB2_PAT }}
         task_definition: 'gh-runner'
         cluster: 'gh-runner'
         task_count: 4


### PR DESCRIPTION
Recentemente tivemos problemas com a utilização das secrets PD_BOT_GITHUB_ACCESS_TOKEN e PD_BOT_ADMIN_GITHUB_ACCESS_TOKEN, como solução foram criadas duas novas com nome de PD_GITHUB2_PAT e PD_GITHUB2_ADMIN_PAT respectivamente, a partir de outro usuário, esse pull request é exatamente para fazer essa substituição para evitar problemas de rate limit