### PR TITLE
feat: usando ubuntu 'noble' ao invés de 'focal';

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nestybox/ubuntu-focal-systemd-docker
+FROM nestybox/ubuntu-noble-systemd-docker
 
 # Extra deps for GHA Runner
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
visto que o ubuntu focal está sendo descontinuado e que a versão lançada por netybox data de 4 anos atrás, ainda usando o cgroup v1, é necessário mudar a imagem base.;